### PR TITLE
Switching the fuzzywuzzy libarray reference to the Real Kinetic fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-fuzzywuzzy
+git+ssh://git@github.com/RealKinetic/fuzzywuzzy.git#egg=fuzzywuzzy


### PR DESCRIPTION
This fork kills the annoying "warning" message that really just ends up
being errors in the logs.

FYI @RealKinetic/devs 